### PR TITLE
Add basic support for Tackle Box

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.9.3'
+def runeLiteVersion = '1.9.8'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/men/groupiron/CustomInventoryId.java
+++ b/src/main/java/men/groupiron/CustomInventoryId.java
@@ -1,0 +1,5 @@
+package men.groupiron;
+
+public class CustomInventoryId {
+    public static final int TACKLE_BOX = 651;
+}

--- a/src/main/java/men/groupiron/DataManager.java
+++ b/src/main/java/men/groupiron/DataManager.java
@@ -56,6 +56,8 @@ public class DataManager {
     @Getter
     private final DataState achievementDiary = new DataState("diary_vars", false);
     @Getter
+    private final DataState tackleBox = new DataState("tackle_box", false);
+    @Getter
     private final DepositedItems deposited = new DepositedItems();
 
     public void submitToApi() {
@@ -100,6 +102,7 @@ public class DataManager {
             deposited.consumeState(updates);
             seedVault.consumeState(updates);
             achievementDiary.consumeState(updates);
+            tackleBox.consumeState(updates);
 
             if (updates.size() > 1) {
                 try {
@@ -168,6 +171,7 @@ public class DataManager {
         deposited.restoreState();
         seedVault.restoreState();
         achievementDiary.restoreState();
+        tackleBox.restoreState();
     }
 
     private String baseUrl() {

--- a/src/main/java/men/groupiron/GroupIronmenTrackerPlugin.java
+++ b/src/main/java/men/groupiron/GroupIronmenTrackerPlugin.java
@@ -139,6 +139,8 @@ public class GroupIronmenTrackerPlugin extends Plugin {
             dataManager.getEquipment().update(newEquipmentState);
         } else if (id == InventoryID.GROUP_STORAGE.getId()) {
             dataManager.getSharedBank().update(new ItemContainerState(playerName, container, itemManager));
+        } else if (id == CustomInventoryId.TACKLE_BOX) {
+            dataManager.getTackleBox().update(new ItemContainerState(playerName, container, itemManager, 32));
         }
     }
 


### PR DESCRIPTION
I added support to track items in Tackle Box when opened. RuneLite did not seem to have this inventory ID set so I added an enum to signify this.

Currently unsupported is the Fill and Empty options on the tackle box which are similar to issues in tracking bank depositing. I didn't know how to approach it or find the right events so I just stopped looking into it. I feel like it's not really that important even if items go "missing" or there are duplicates in the list because of it.