### PR TITLE
Add config toggles for controlling sync for container items

### DIFF
--- a/src/main/java/men/groupiron/GroupIronmenTrackerConfig.java
+++ b/src/main/java/men/groupiron/GroupIronmenTrackerConfig.java
@@ -15,6 +15,13 @@ public interface GroupIronmenTrackerConfig extends Config {
     String groupSection = "GroupSection";
 
     @ConfigSection(
+            name = "Player Config",
+            description = "Configure your container item sync settings",
+            position = 0
+    )
+    String playerSection = "PlayerSection";
+
+    @ConfigSection(
             name = "Self Hosted Config",
             description = "Configure your connection to a self hosted server",
             position = 1,
@@ -41,6 +48,46 @@ public interface GroupIronmenTrackerConfig extends Config {
     )
     default String authorizationToken() {
         return "";
+    }
+
+    @ConfigItem(
+            keyName = "hideBankContents",
+            name = "Hide bank contents",
+            description = "Toggle sharing of bank contents to the rest of the group",
+            section = playerSection
+    )
+    default boolean hideBankContents() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "hideSeedVaultContents",
+            name = "Hide seed vault contents",
+            description = "Toggle sharing of seed vault contents to the rest of the group",
+            section = playerSection
+    )
+    default boolean hideSeedVaultContents() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "hideInventoryContents",
+            name = "Hide inventory contents",
+            description = "Toggle sharing of inventory contents to the rest of the group",
+            section = playerSection
+    )
+    default boolean hideInventoryContents() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "hideEquipmentContents",
+            name = "Hide Equipment contents",
+            description = "Toggle sharing of Equipment contents to the rest of the group",
+            section = playerSection
+    )
+    default boolean hideEquipmentContents() {
+        return false;
     }
 
     @ConfigItem(

--- a/src/main/java/men/groupiron/GroupIronmenTrackerPlugin.java
+++ b/src/main/java/men/groupiron/GroupIronmenTrackerPlugin.java
@@ -133,29 +133,31 @@ public class GroupIronmenTrackerPlugin extends Plugin {
         final int id = event.getContainerId();
         ItemContainer container = event.getItemContainer();
 
-        if (id == InventoryID.BANK.getId()) {
-            dataManager.getDeposited().reset();
-            dataManager.getBank().update(new ItemContainerState(playerName, container, itemManager));
-        } else if (id == InventoryID.SEED_VAULT.getId()) {
-            dataManager.getSeedVault().update(new ItemContainerState(playerName, container, itemManager));
-        } else if (id == InventoryID.INVENTORY.getId()) {
+        if (id == COLLECTION_LOG_INVENTORYID) {
+            collectionLogManager.updateCollection(new ItemContainerState(playerName, container, itemManager));
+        }
+
+        if (id == InventoryID.INVENTORY.getId() && !config.hideInventoryContents()) {
             ItemContainerState newInventoryState = new ItemContainerState(playerName, container, itemManager, 28);
             if (itemsDeposited > 0) {
                 updateDeposited(newInventoryState, (ItemContainerState) dataManager.getInventory().mostRecentState());
             }
-
             dataManager.getInventory().update(newInventoryState);
-        } else if (id == InventoryID.EQUIPMENT.getId()) {
+        } else if (id == InventoryID.EQUIPMENT.getId() && !config.hideEquipmentContents()){
             ItemContainerState newEquipmentState = new ItemContainerState(playerName, container, itemManager, 14);
             if (itemsDeposited > 0) {
                 updateDeposited(newEquipmentState, (ItemContainerState) dataManager.getEquipment().mostRecentState());
             }
-
             dataManager.getEquipment().update(newEquipmentState);
-        } else if (id == InventoryID.GROUP_STORAGE.getId()) {
+        } else if (id == InventoryID.BANK.getId() && !config.hideBankContents()) {
+            dataManager.getDeposited().reset();
+            dataManager.getBank().update(new ItemContainerState(playerName, container, itemManager));
+        } else if (id == InventoryID.SEED_VAULT.getId() && !config.hideSeedVaultContents()) {
+            dataManager.getSeedVault().update(new ItemContainerState(playerName, container, itemManager));
+        }
+
+        if (id == InventoryID.GROUP_STORAGE.getId()) {
             dataManager.getSharedBank().update(new ItemContainerState(playerName, container, itemManager));
-        } else if (id == COLLECTION_LOG_INVENTORYID) {
-            collectionLogManager.updateCollection(new ItemContainerState(playerName, container, itemManager));
         }
     }
 


### PR DESCRIPTION
Add config toggles to make sharing of bank contents optional between the group.
Toggles added for:

- bank
- seed vault
- inventory
- equipment

No toggle added for the group bank, as it's shared by default.