### PR TITLE
avoid transmitting non-main-game profile data

### DIFF
--- a/src/main/java/men/groupiron/DataManager.java
+++ b/src/main/java/men/groupiron/DataManager.java
@@ -15,8 +15,6 @@ import java.util.Map;
 @Singleton
 public class DataManager {
     @Inject
-    Client client;
-    @Inject
     GroupIronmenTrackerConfig config;
     @Inject
     private CollectionLogManager collectionLogManager;
@@ -56,11 +54,9 @@ public class DataManager {
     @Getter
     private final DepositedItems deposited = new DepositedItems();
 
-    public void submitToApi() {
-        if (client.getLocalPlayer() == null || client.getLocalPlayer().getName() == null || isBadWorldType()) return;
+    public void submitToApi(String playerName) {
         if (skipNextNAttempts-- > 0) return;
 
-        String playerName = client.getLocalPlayer().getName();
         String groupToken = config.authorizationToken().trim();
 
         if (groupToken.length() > 0) {
@@ -179,21 +175,5 @@ public class DataManager {
         if (baseUrl == null || groupName == null) return null;
 
         return String.format("%s/api/group/%s/am-i-in-group?member_name=%s", baseUrl, groupName, playerName);
-    }
-
-    private boolean isBadWorldType() {
-        EnumSet<WorldType> worldTypes = client.getWorldType();
-        for (WorldType worldType : worldTypes) {
-            if (worldType == WorldType.SEASONAL ||
-                    worldType == WorldType.DEADMAN ||
-                    worldType == WorldType.TOURNAMENT_WORLD ||
-                    worldType == WorldType.PVP_ARENA ||
-                    worldType == WorldType.BETA_WORLD ||
-                    worldType == WorldType.QUEST_SPEEDRUNNING) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/main/java/men/groupiron/GroupIronmenTrackerPlugin.java
+++ b/src/main/java/men/groupiron/GroupIronmenTrackerPlugin.java
@@ -13,6 +13,7 @@ import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.RuneScapeProfileType;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
@@ -82,7 +83,11 @@ public class GroupIronmenTrackerPlugin extends Plugin {
             asynchronous = true
     )
     public void submitToApi() {
-        dataManager.submitToApi();
+        if(doNotUseThisData())
+            return;
+
+        String playerName = client.getLocalPlayer().getName();
+        dataManager.submitToApi(playerName);
     }
 
     @Schedule(
@@ -118,7 +123,8 @@ public class GroupIronmenTrackerPlugin extends Plugin {
 
     @Subscribe
     public void onVarbitChanged(VarbitChanged event) {
-        if (doNotUseThisData()) return;
+        if (doNotUseThisData())
+            return;
 
         final int varpId = event.getVarpId();
         if (varpId == VarPlayerID.DIZANAS_QUIVER_TEMP_AMMO || varpId == VarPlayerID.DIZANAS_QUIVER_TEMP_AMMO_AMOUNT) {
@@ -129,6 +135,9 @@ public class GroupIronmenTrackerPlugin extends Plugin {
 
     @Subscribe
     public void onGameTick(GameTick gameTick) {
+        if(doNotUseThisData())
+            return;
+
         --itemsDeposited;
         updateInteracting();
 
@@ -184,6 +193,9 @@ public class GroupIronmenTrackerPlugin extends Plugin {
 
     @Subscribe
     private void onScriptPostFired(ScriptPostFired event) {
+        if(doNotUseThisData())
+            return;
+
         if (event.getScriptId() == CHATBOX_ENTERED && client.getWidget(InterfaceID.BankDepositbox.INVENTORY) != null) {
             itemsMayHaveBeenDeposited();
         }
@@ -191,6 +203,9 @@ public class GroupIronmenTrackerPlugin extends Plugin {
 
     @Subscribe
     private void onMenuOptionClicked(MenuOptionClicked event) {
+        if(doNotUseThisData())
+            return;
+
         final int param1 = event.getParam1();
         final MenuAction menuAction = event.getMenuAction();
         if (menuAction == MenuAction.CC_OP) {
@@ -202,6 +217,9 @@ public class GroupIronmenTrackerPlugin extends Plugin {
 
     @Subscribe
     private void onInteractingChanged(InteractingChanged event) {
+        if(doNotUseThisData())
+            return;
+
         if (event.getSource() != client.getLocalPlayer()) return;
         updateInteracting();
     }
@@ -210,6 +228,7 @@ public class GroupIronmenTrackerPlugin extends Plugin {
     private void onChatMessage(ChatMessage chatMessage) {
         if (doNotUseThisData())
             return;
+
         if (chatMessage.getType() != ChatMessageType.GAMEMESSAGE) return;
 
         Matcher matcher = COLLECTION_LOG_ITEM_PATTERN.matcher(chatMessage.getMessage());
@@ -224,6 +243,9 @@ public class GroupIronmenTrackerPlugin extends Plugin {
     @Subscribe
     public void onScriptPreFired(ScriptPreFired scriptPreFired)
     {
+        if(doNotUseThisData())
+            return;
+
         switch (scriptPreFired.getScriptId())
         {
             case ScriptID.NOTIFICATION_START:
@@ -271,8 +293,12 @@ public class GroupIronmenTrackerPlugin extends Plugin {
         dataManager.getDeposited().update(deposited);
     }
 
+    /**
+     * A guard blocking client callbacks that may write invalid state, such as when the player is not logged in to a main-game profile.
+     */
     private boolean doNotUseThisData() {
-        return client.getGameState() != GameState.LOGGED_IN || client.getLocalPlayer() == null;
+        boolean isStandardProfile = RuneScapeProfileType.getCurrent(client) == RuneScapeProfileType.STANDARD;
+        return client.getGameState() != GameState.LOGGED_IN || client.getLocalPlayer() == null || !isStandardProfile;
     }
 
     @Provides


### PR DESCRIPTION
I found that it is possible to smuggle seasonal data if you load the bank, then immediately hop, since the world type is only checked on transmission. With the help of a builtin RuneLite profile enum, this fix adds extra checks that ensures non-main-game profile data is neither written nor transmitted.